### PR TITLE
Fix docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM liquibase/liquibase:latest
+FROM liquibase/liquibase:4.2.2
 
 COPY entry.sh /entry.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM liquibase/liquibase:4.1
+FROM liquibase/liquibase:latest
 
 COPY entry.sh /entry.sh
 


### PR DESCRIPTION
Updated to use latest liquibase docker image which has docker_entrypoint in path and root directory as sym links.