### PR TITLE
add licenseKey parameter and deprecate proLicenseKey (DAT-10022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ The `operation` input expects one of the following:
 
 ### Optional Inputs
 
-`username`, `password`, `url`, `classpath`, `changeLogFile`, `count`, `tag`, `date`, `referenceUrl`, `proLicenseKey` and `hubApiKey` are optional inputs that may be required by some operations.
+`username`, `password`, `url`, `classpath`, `changeLogFile`, `count`, `tag`, `date`, `referenceUrl`, `proLicenseKey` (deprecated in favor of `licenseKey`) and `hubApiKey` are optional inputs that may be required by some operations.
 
-It is recommended that `proLicenseKey` and `hubApiKey` are not stored in plaintext, but rather using a [GitHub secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets):
+It is recommended that `licenseKey` and `hubApiKey` are not stored in plaintext, but rather using a [GitHub secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets):
 
 ```
-          proLicenseKey: ${{ secrets.PRO_LICENSE_KEY }}
+          licenseKey: ${{ secrets.PRO_LICENSE_KEY }}
 ```
 
 The following operations have the subsequent required inputs:

--- a/action.yml
+++ b/action.yml
@@ -36,10 +36,13 @@ inputs:
     description: 'Configuration file for checks execution'
     required: false
   proLicenseKey: # string
-    description: 'Liquibase Pro license key used to unlock paid capabilities'
+    description: 'DEPRECATED: Liquibase Pro license key used to unlock paid capabilities'
     required: false
   hubApiKey: # string
     description: 'Liquibase Hub API key for operations'
+    required: false
+  licenseKey: # string
+    description: 'Liquibase license key used to unlock paid capabilities'
     required: false
 runs:
   using: 'docker'
@@ -58,6 +61,7 @@ runs:
     - ${{ inputs.checksSettingsFile }}
     - ${{ inputs.proLicenseKey }}
     - ${{ inputs.hubApiKey }}
+    - ${{ inputs.licenseKey }}
 branding:
   icon: database
   color: red

--- a/entry.sh
+++ b/entry.sh
@@ -13,6 +13,7 @@ REFERENCEURL=${10}
 CHECKSSETTINGSFILE=${11}
 PROLICENSEKEY=${12}
 HUBAPIKEY=${13}
+LICENSEKEY=${14}
 
 PARAMS=()
 VALUES=()
@@ -179,6 +180,7 @@ function validate_operation() {
 
 check_optional_param "$OPERATION" proLicenseKey $PROLICENSEKEY
 check_optional_param "$OPERATION" hubApiKey $HUBAPIKEY
+check_optional_param "$OPERATION" licenseKey $LICENSEKEY
 validate_operation
 
 docker-entrypoint.sh "${PARAMS[@]}" $OPERATION "${VALUES[@]}" "${SECONDPARAMS[@]}"


### PR DESCRIPTION
This adds the `licenseKey` parameter that we're adding in the work for QCs for databases. As a result, this PR should not be merged or released until after we merge and release the QCs for databases work.