### PR TITLE
add support for contexts parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ It is recommended that `licenseKey` and `hubApiKey` are not stored in plaintext,
 ```
 
 The following operations have the subsequent required inputs:
+#### update
+
+- username
+- password
+- url
+- classpath
+- changeLogFile
+- contexts (optional)
+- databaseChangeLogTableName (optional)
+- databaseChangeLogLockTableName (optional)
 
 #### updateCount
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   changeLogFile: # string
     description: 'Name of Change Log File'
     required: false
+  contexts: # string
+    description: 'Contexts'
+    required: false
   username: # string
     description: 'Database Username'
     required: false
@@ -70,6 +73,7 @@ runs:
     - ${{ inputs.licenseKey }}
     - ${{ inputs.databaseChangeLogTableName }}
     - ${{ inputs.databaseChangeLogLockTableName }}
+    - ${{ inputs.contexts }}
 branding:
   icon: database
   color: red

--- a/entry.sh
+++ b/entry.sh
@@ -16,6 +16,7 @@ HUBAPIKEY=${13}
 LICENSEKEY=${14}
 DATABASECHANGELOGTABLENAME=${15}
 DATABASECHANGELOGLOCKTABLENAME=${16}
+CONTEXTS=${17}
 
 PARAMS=()
 VALUES=()
@@ -72,6 +73,7 @@ function validate_operation() {
         check_required_param update url $URL
         check_optional_param update databaseChangeLogTableName $DATABASECHANGELOGTABLENAME
         check_optional_param update databaseChangeLogLockTableName $DATABASECHANGELOGLOCKTABLENAME
+        check_optional_param update contexts $CONTEXTS
         ;;
 
     updateCount)


### PR DESCRIPTION
Add support for the contexts parameter. This parameter can be used to pass contexts (e.g. qa or production environment) to the liquibase action in github workflows.